### PR TITLE
Fixed generation of type expressions for primitive array types like `string[]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2023-04-19
+
+### Fixed
+
+* Typeguards for primitive array types, such as `string[]`, were not generated correctly
+
 ## [1.2.0] - 2023-04-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typeguardian",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "A tool for generating typeguard functions in TypeScript.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
Type expressions for primitive array types like `string[]` were getting generated in a way that checked the array property instead of its elements:

`data.stringArrayProp.every(() => typeof data.stringArrayProp === 'string')`

This PR corrects these type expressions to check the elements directly:

`data.stringArrayProp.every((el) => typeof el === 'string')`