### PR TITLE
Added support for `Date` and `extends`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2023-04-20
+
+### Added
+
+* The correct type check is now made for `Date` types
+* Interfaces that extend another interface are now supported
+
 ## [1.2.1] - 2023-04-19
 
 ### Fixed

--- a/app/assets/js/src/typeguardian/TypeDef.ts
+++ b/app/assets/js/src/typeguardian/TypeDef.ts
@@ -1,5 +1,6 @@
 export type TypeDef = {
 	name: string,
+	extendedInterface?: string,
 	props: Array<[string, string]>,
 	exported: boolean,
 };

--- a/app/assets/js/src/typeguardian/readTypeDef.ts
+++ b/app/assets/js/src/typeguardian/readTypeDef.ts
@@ -38,12 +38,13 @@ export function readTypeDef(typedef: string): TypeDef {
 		throw new Error(`Couldn't read empty type definition`);
 	}
 
-	const nameMatch = lines[0].match(/^(export\s+)?(type|interface)\s+(\w+)\s*=?\s*{(\s*\/\/.*)?$/);
+	const nameMatch = lines[0].match(/^(export\s+)?(type|interface)\s+(\w+)( extends (\w+))?\s*=?\s*{(\s*\/\/.*)?$/);
 	if (!nameMatch) {
 		throw new Error(`Couldn't determine name of custom type`);
 	}
 	const exported = Boolean(nameMatch[1]);
 	const name = nameMatch[3];
+	const extendedInterface = nameMatch[5];
 
 	// Ignore first and last line
 	const propLines = lines.slice(1, -1);
@@ -72,9 +73,15 @@ export function readTypeDef(typedef: string): TypeDef {
 		return [propName, propType] as [string, string];
 	}).filter((el): el is NonNullable<typeof el> => Boolean(el));
 
-	return {
+	const typeDef: TypeDef = {
 		name,
 		props,
 		exported,
 	};
+
+	if (extendedInterface) {
+		typeDef.extendedInterface = extendedInterface;
+	}
+
+	return typeDef;
 }

--- a/app/assets/js/src/typeguardian/writeTypeAssertionFunction.ts
+++ b/app/assets/js/src/typeguardian/writeTypeAssertionFunction.ts
@@ -17,6 +17,7 @@ export function writeTypeAssertionFunction(typedefArg: TypeDef | string, indent 
 
 	const {
 		name,
+		extendedInterface,
 		props,
 		exported,
 	} = typedef;
@@ -31,12 +32,18 @@ export function writeTypeAssertionFunction(typedefArg: TypeDef | string, indent 
 function ${writeTypeAssertionName(name)}(testData: unknown, errorLogger?: (message: string) => void): asserts testData is ${name} {
 ${indent}const data = testData as ${name};
 
-${indent}if (!(
+${
+	extendedInterface
+	? `${indent}if (!(${writeTypeguardName(extendedInterface)}(data))) {
+${indent}${indent}throw new TypeError('Tested value was not of type \`${extendedInterface}\`');
+${indent}}`
+	: `${indent}if (!(
 ${indent}${indent}typeof data === 'object' &&
 ${indent}${indent}data !== null
 ${indent})) {
 ${indent}${indent}throw new TypeError('Tested value was not an object');
-${indent}}
+${indent}}`
+}
 
 ${indent}${props.map(([propName, propType]) => `if (!(${writeTypeguardExpression(propName, propType, {
 	indent,

--- a/app/assets/js/src/typeguardian/writeTypeguardExpression.ts
+++ b/app/assets/js/src/typeguardian/writeTypeguardExpression.ts
@@ -84,6 +84,12 @@ ${baseIndent}${indent}${unionMembers.map((type) => writeTypeguardExpression(prop
 ${baseIndent}`;
 	}
 
+	// Date
+	const isDate = propType === 'Date';
+	if (isDate) {
+		return `data.${propName} instanceof Date`;
+	}
+
 	// Custom types
 	const isCustomType = (customTypePattern).test(propType);
 	if (isCustomType) {

--- a/app/assets/js/src/typeguardian/writeTypeguardFunction.ts
+++ b/app/assets/js/src/typeguardian/writeTypeguardFunction.ts
@@ -9,16 +9,17 @@ import { writeTypeguardName } from './writeTypeguardName.js';
  *
  * This function is intended to be used for generating code, not actually run within the browser.
  */
-export function writeTypeguardFunction(typedef: TypeDef, indent?: string): string
-export function writeTypeguardFunction(typedefString: string, indent?: string): string
-export function writeTypeguardFunction(typedefArg: TypeDef | string, indent = '    '): string {
-	const typedef = typeof typedefArg === 'string' ? readTypeDef(typedefArg) : typedefArg;
+export function writeTypeguardFunction(typeDef: TypeDef, indent?: string): string
+export function writeTypeguardFunction(typeDefString: string, indent?: string): string
+export function writeTypeguardFunction(typeDefArg: TypeDef | string, indent = '    '): string {
+	const typeDef = typeof typeDefArg === 'string' ? readTypeDef(typeDefArg) : typeDefArg;
 
 	const {
 		name,
+		extendedInterface,
 		props,
 		exported,
-	} = typedef;
+	} = typeDef;
 
 	const typeguard = `/**
  * Typeguard function for {@linkcode ${name}}
@@ -28,12 +29,18 @@ export function writeTypeguardFunction(typedefArg: TypeDef | string, indent = ' 
 ${exported ? 'export ' : ''}function ${writeTypeguardName(name)}(testData: unknown): testData is ${name} {
 ${indent}const data = testData as ${name};
 
-${indent}if (!(
+${
+	extendedInterface
+	? `${indent}if (!(${writeTypeguardName(extendedInterface)}(data))) {
+${indent}${indent}return false;
+${indent}}`
+	: `${indent}if (!(
 ${indent}${indent}typeof data === 'object' &&
 ${indent}${indent}data !== null
 ${indent})) {
 ${indent}${indent}return false;
-${indent}}
+${indent}}`
+}
 
 ${indent}${props.map(([propName, propType]) => `if (!(${writeTypeguardExpression(propName, propType, {
 	indent,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typeguardian",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"description": "A tool for generating typeguard functions in TypeScript.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
This PR adds support for writing typeguards for interfaces that extend other interfaces, by calling the typeguard for those base interfaces instead of starting with the standard object check, and for checking properties of type `Date` by using the `instanceof` operator.