### PR TITLE
Added support for `any` and `unknown` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2023-04-21
+
+### Added
+
+* Can now have properties typed `any` (telling TypeScript you don't care about the type, not recommended) or `unknown` (essentially deferring a type check, typically only recommended for deprecated properties)
+
 ## [1.3.0] - 2023-04-20
 
 ### Added

--- a/app/assets/js/src/typeguardian/writeTypeguardExpression.ts
+++ b/app/assets/js/src/typeguardian/writeTypeguardExpression.ts
@@ -76,6 +76,13 @@ ${baseIndent}`;
 	}
 
 	if (unionMembers.length > 1) {
+		// If a union includes `any` or `unknown` there's no point in checking its other union members
+		if (unionMembers.includes('any')) {
+			return writeTypeguardExpression(propName, 'any', options);
+		} else if (unionMembers.includes('unknown')) {
+			return writeTypeguardExpression(propName, 'unknown', options);
+		}
+
 		return `
 ${baseIndent}${indent}${unionMembers.map((type) => writeTypeguardExpression(propName, type, {
 	indent,
@@ -88,6 +95,13 @@ ${baseIndent}`;
 	const isDate = propType === 'Date';
 	if (isDate) {
 		return `data.${propName} instanceof Date`;
+	}
+
+	// `any` and `unknown`
+	const isUncheckable = propType === 'any' || propType === 'unknown';
+	if (isUncheckable) {
+		// No narrowing is needed for these types
+		return 'true';
 	}
 
 	// Custom types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typeguardian",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "A tool for generating typeguard functions in TypeScript.",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
This PR adds support for `any` and `unknown` types, both of which use `true` for their check instead of actually being checked.

Using `any` is not recommended, as it's essentially telling TypeScript that you don't care about something's type.

Using `unknown` is essentially deferring a type check. It can be useful for if you want to document a deprecated property, but don't actually want to check its format.